### PR TITLE
Add Deps Install For Go And Add Logic To Generate Swagger Spec

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches-ignore:
       - main
-  pull_request:
-    branches:
-      - main
       
 jobs:
   test:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,15 @@ PROTO_DIRS := $(wildcard proto*)
 PROTO_FILES := $(foreach dir,$(PROTO_DIRS),$(wildcard $(dir)/*.proto))
 OUT_DIR := .
 
+deps:
+	go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+	go install github.com/bufbuild/buf/cmd/buf@latest
+	go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@latest
+	go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@latest
+	go install github.com/fullstorydev/grpcui/cmd/grpcui@latest
+	go install github.com/mitchellh/protoc-gen-go-json@latest
+
 proto:
 	buf dep update
 	buf generate

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -20,3 +20,5 @@ plugins:
     opt:
       - paths=import
       - module=github.com/RyanDerr/GoKeyValueStore
+  - name: openapiv2
+    out: proto-public/openapiv2

--- a/proto-public/go/keyvalue.pb.gw.go
+++ b/proto-public/go/keyvalue.pb.gw.go
@@ -65,6 +65,7 @@ func request_KeyValueService_Get_0(ctx context.Context, marshaler runtime.Marsha
 		metadata runtime.ServerMetadata
 		err      error
 	)
+	io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["key"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "key")
@@ -101,6 +102,7 @@ func request_KeyValueService_Delete_0(ctx context.Context, marshaler runtime.Mar
 		metadata runtime.ServerMetadata
 		err      error
 	)
+	io.Copy(io.Discard, req.Body)
 	val, ok := pathParams["key"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "key")

--- a/proto-public/openapiv2/proto-public/keyvalue.swagger.json
+++ b/proto-public/openapiv2/proto-public/keyvalue.swagger.json
@@ -1,0 +1,178 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "proto-public/keyvalue.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "KeyValueService"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1/cache/delete/{key}": {
+      "delete": {
+        "operationId": "KeyValueService_Delete",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/KeyValueStoreDeleteResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "KeyValueService"
+        ]
+      }
+    },
+    "/v1/cache/get/{key}": {
+      "get": {
+        "operationId": "KeyValueService_Get",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/KeyValueStoreGetResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "KeyValueService"
+        ]
+      }
+    },
+    "/v1/cache/set": {
+      "post": {
+        "operationId": "KeyValueService_Set",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/KeyValueStoreSetResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/KeyValueStoreSetRequest"
+            }
+          }
+        ],
+        "tags": [
+          "KeyValueService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "KeyValueStoreDeleteResponse": {
+      "type": "object"
+    },
+    "KeyValueStoreGetResponse": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "KeyValueStoreSetRequest": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "KeyValueStoreSetResponse": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Overview
<!-- Provide a brief overview and or bullet point of changes made -->
- Update `Makefile` to install go deps.
- Add spec to `buf` to generate `swagger` documentation for http endpoints. 
- Remove PR tests, this should just run on every push except for main for the `test.yml` workflow. 
## Testing
<!-- Enumerate details if any for testing that was done before publishing PR -->
- @bgajjala8 Can you please test the command `make deps` and see after which if you can run `make proto`, the first command should install all the required dependencies, but want to confirm if any are missing. 
## Checklist 
- [ ] If applicable, I've documented a plan to revert these changes if it requires more than reverting the PR. 

## Notes
<!-- Any additional details to provide regarding the PR -->
N/A