### PR TITLE
Update Workflow To Explicitly Set Execution Perms Instead Of Inheriting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches-ignore:
       - main
-      
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   test:
     name: Test, Lint, and Security Scan


### PR DESCRIPTION
## Overview
<!-- Provide a brief overview and or bullet point of changes made -->
- Set `Test` workflow permission to allow `contents: read` and pr `write` instead of inheriting the repository's base settings for workflow executions. 
   - Detected from [CWE-275](https://github.com/RyanDerr/GoKeyValueStore/security/code-scanning/1)
## Testing
<!-- Enumerate details if any for testing that was done before publishing PR -->
N/A
## Checklist 
- [ ] If applicable, I've documented a plan to revert these changes if it requires more than reverting the PR. 
N/A
## Notes
<!-- Any additional details to provide regarding the PR -->
N/A